### PR TITLE
resolved [Ambiguous Match Found] exception in AOP package

### DIFF
--- a/src/Asmin/Asmin.Business/Concrete/UserManager.cs
+++ b/src/Asmin/Asmin.Business/Concrete/UserManager.cs
@@ -10,6 +10,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Asmin.Entities.CustomEntities.Request.User;
+using Asmin.Packages.AOP.Aspects.Exception;
+using Asmin.Packages.AOP.Aspects.Transaction;
 using Asmin.Packages.Hashing.Core.Service;
 
 namespace Asmin.Business.Concrete
@@ -27,10 +29,10 @@ namespace Asmin.Business.Concrete
             _hashService = hashService;
         }
 
+        [AsminExceptionAspect]
+        [AsminUnitOfWorkAspect]
         public async Task<IResult> AddAsync(User user)
         {
-            user.Password = _hashService.Generate(user.Password);
-
             var validationResult = await _userValidator.ValidateAsync(user);
 
             if (!validationResult.IsValid)
@@ -38,6 +40,8 @@ namespace Asmin.Business.Concrete
                 var firstErrorMessage = validationResult.Errors.Select(failure => failure.ErrorMessage).FirstOrDefault();
                 return new ErrorResult(firstErrorMessage);
             }
+
+            user.Password = _hashService.Generate(user.Password);
 
             await _userDal.AddAsync(user);
             return new SuccessResult(ResultMessages.UserAdded);

--- a/src/Asmin/Asmin.Business/ValidationRules/FluentValidation/UserValidator.cs
+++ b/src/Asmin/Asmin.Business/ValidationRules/FluentValidation/UserValidator.cs
@@ -3,9 +3,11 @@ using FluentValidation;
 using System;
 using System.Collections.Generic;
 using System.Text;
+using Asmin.Packages.AOP.Attributes;
 
 namespace Asmin.Business.ValidationRules.FluentValidation
 {
+    [IgnoreAOP]
     public class UserValidator : AbstractValidator<User>
     {
         public UserValidator()

--- a/src/Asmin/Asmin.Packages.AOP/Attributes/IgnoreAOPAttribute.cs
+++ b/src/Asmin/Asmin.Packages.AOP/Attributes/IgnoreAOPAttribute.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Asmin.Packages.AOP.Attributes
+{
+    /// <summary>
+    /// Reflection sometimes throws exception like 'Ambiguous match found' when creating instance. It attribute ignores class when interceptor loaded.
+    /// </summary>
+    public class IgnoreAOPAttribute : Attribute
+    {
+
+    }
+}

--- a/src/Asmin/Asmin.Packages.AOP/InterceptModule/AutofacInterceptorModule.cs
+++ b/src/Asmin/Asmin.Packages.AOP/InterceptModule/AutofacInterceptorModule.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Reflection;
 using System.Text;
+using Asmin.Packages.AOP.Attributes;
 using Asmin.Packages.AOP.Interceptor;
 using Autofac;
 using Autofac.Extras.DynamicProxy;
@@ -22,6 +24,12 @@ namespace Asmin.Packages.AOP.InterceptModule
         protected override void Load(ContainerBuilder builder)
         {
             builder.RegisterAssemblyTypes(_assembly)
+                .Where(type =>
+                {
+                    var checkHasIgnoreAttribute = type.GetCustomAttributes(false).Any(attribute => attribute.GetType().Name == nameof(IgnoreAOPPackageAttribute));
+
+                    return !checkHasIgnoreAttribute;
+                })
                 .AsImplementedInterfaces()
                 .EnableInterfaceInterceptors(new ProxyGenerationOptions()
                 {

--- a/src/Asmin/Asmin.Packages.AOP/InterceptModule/AutofacInterceptorModule.cs
+++ b/src/Asmin/Asmin.Packages.AOP/InterceptModule/AutofacInterceptorModule.cs
@@ -26,7 +26,7 @@ namespace Asmin.Packages.AOP.InterceptModule
             builder.RegisterAssemblyTypes(_assembly)
                 .Where(type =>
                 {
-                    var checkHasIgnoreAttribute = type.GetCustomAttributes(false).Any(attribute => attribute.GetType().Name == nameof(IgnoreAOPPackageAttribute));
+                    var checkHasIgnoreAttribute = type.GetCustomAttributes(false).Any(attribute => attribute.GetType().Name == nameof(IgnoreAOPAttribute));
 
                     return !checkHasIgnoreAttribute;
                 })


### PR DESCRIPTION
Reflection sometimes throws exception when resolve class/interface. I defined **IgnoreAOPAttribute.cs** class for ignore some classes when resolving.

Usages basically:

```csharp
[IgnoreAOP]
public class UserValidator : AbstractValidator<User>
{
    public UserValidator()
    {
        RuleFor(user => user.FirstName)
            .NotEmpty();

        RuleFor(user => user.LastName)
            .NotEmpty();

        RuleFor(user => user.Email)
            .EmailAddress();

        RuleFor(user => user.Password)
            .NotEmpty();
    }
}
```

Autofac ignores those classes when module load such as following code:

```csharp
protected override void Load(ContainerBuilder builder)
{
    builder.RegisterAssemblyTypes(_assembly)
        .Where(type =>
        {
            var checkHasIgnoreAttribute = type.GetCustomAttributes(false).Any(attribute => attribute.GetType().Name == nameof(IgnoreAOPAttribute));

            return !checkHasIgnoreAttribute;
        })
        .AsImplementedInterfaces()
        .EnableInterfaceInterceptors(new ProxyGenerationOptions()
        {
            Selector = new AspectInterceptorSelector()
        })
        .SingleInstance();
}
``` 